### PR TITLE
upgrade toolchain to 1.93

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92"
+channel = "1.93"
 profile = "minimal"


### PR DESCRIPTION
Upgrades Rust toolchain from previous version to 1.93